### PR TITLE
Clear fGattBusy flag in `writeChunkOfData` when `mData2Write` is null

### DIFF
--- a/android/bgxpress/src/main/java/com/silabs/bgxpress/BGXpressService.java
+++ b/android/bgxpress/src/main/java/com/silabs/bgxpress/BGXpressService.java
@@ -2019,6 +2019,8 @@ public class BGXpressService extends IntentService {
                         }
 
                     }
+                } else {
+                    clearGattBusyFlagAndExecuteNext();
                 }
             }
         }


### PR DESCRIPTION
## Issue:

Our Android application was using the Android "bgxpress" module code committed on Nov 7, 2019 (https://github.com/SiliconLabs/wireless-xpress/commit/b50b15c3454b8437f4efb04ae5a4581144fcec74). I was getting an error on Android OS 10 while communicating with the BGX13P device.

To fix the issue on Android 10, I updated my application to use the latest Android "bgxpress" module code committed in May 2020. My app is working fine now on Android OS 10. However, it is no longer working on Android OS 7. I am not getting any error in my logs but after some time, my application is not getting any data back in `BGX_DATA_RECEIVED` intent.  

On Android 7.0, the BGXpressService never clears `fGattBusy` flag in `writeChunkOfData` when `mData2Write` is null after one point.

- When BGXpressService is called with `ACTION_WRITE_SERIAL_BIN_DATA`, it will call `queueGattIntent()` in BGXpressService.
- `queueGattIntent()` checks `fGattBusy` flag and will call `executeNextGattIntent()` if `fGattBusy` is false.
- `executeNextGattIntent()` will eventually call `writeChunckOfData` which will write a bit of data to the Rx characteristic by calling `writeCharacteristic` on BluetoothGatt. It will be called again from `OnCharacteristicWrite` until all of the string has been written. The last call to this function clears `mDataWrite` which indicates to `OnCharacteristicWrite` that no further calls to this function are needed in which case it calls `clearGattBusyFlagAndExecuteNext()`.
- On Android 7.0, looks like it never clears the `fGattBusy` flag. The `OnCharacteristicWrite` callback happens before `mDataWrite` clears in `writeChunkOfData`. This will lead to calling `writeChunckOfData` again from `OnCharacteristicWrite` and also set `mDataWrite` to null from the previous call to `writeChunkOfData`. As `mDataWrite` is null when `writeChunkOfData` gets called again, it will not run anything and won't clear `fGattBusy` flag. This will cause all subsequent write/read operations to be failed.
 

## Silicon Lab's support case number:
Support case # 00229487.
